### PR TITLE
[GP-361] Fix rlp-email-templates integration, allow to run Mercury in dev mode again.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,12 +50,20 @@
         "fastq": "^1.6.0"
       }
     },
-    "@octokit/endpoint": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
-      "integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
+    "@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "requires": {
-        "@octokit/types": "^5.0.0",
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "requires": {
+        "@octokit/types": "^6.0.3",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -67,27 +75,72 @@
         }
       }
     },
+    "@octokit/openapi-types": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+      "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+      "requires": {
+        "@octokit/types": "^2.0.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "requires": {
+        "@octokit/types": "^2.0.1",
+        "deprecation": "^2.3.1"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "2.16.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+          "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        }
+      }
+    },
     "@octokit/request": {
-      "version": "5.4.9",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
-      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
-        "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^5.0.0",
-        "deprecation": "^2.0.0",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "once": "^1.4.0",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "dependencies": {
         "@octokit/request-error": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
-          "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+          "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
           "requires": {
-            "@octokit/types": "^5.0.1",
+            "@octokit/types": "^6.0.3",
             "deprecation": "^2.0.0",
             "once": "^1.4.0"
           }
@@ -120,11 +173,15 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.28.9",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.9.tgz",
-      "integrity": "sha512-IKGnX+Tvzt7XHhs8f4ajqxyJvYAMNX5nWfoJm4CQj8LZToMiaJgutf5KxxpxoC3y5w7JTJpW5rnWnF4TsIvCLA==",
+      "version": "16.43.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+      "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
       "requires": {
-        "@octokit/request": "^5.0.0",
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/plugin-paginate-rest": "^1.1.1",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
+        "@octokit/request": "^5.2.0",
         "@octokit/request-error": "^1.0.2",
         "atob-lite": "^2.0.0",
         "before-after-hook": "^2.0.0",
@@ -139,11 +196,11 @@
       }
     },
     "@octokit/types": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
-      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
       "requires": {
-        "@types/node": ">= 8"
+        "@octokit/openapi-types": "^11.2.0"
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -383,7 +440,7 @@
     "atob-lite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -397,9 +454,9 @@
       "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
     },
     "before-after-hook": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
     },
     "boolify": {
       "version": "1.0.1",
@@ -434,7 +491,7 @@
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
+      "integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -2177,9 +2234,9 @@
       "dev": true
     },
     "macos-release": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
-      "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",
+      "integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g=="
     },
     "make-plural": {
       "version": "4.3.0",
@@ -2609,9 +2666,12 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "npm-run-path": {
       "version": "3.1.0",
@@ -3572,6 +3632,11 @@
         "hoek": "4.x.x"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -3699,6 +3764,20 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mercury-bot",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Mercury is a bot for managing in-code static translations",
   "main": "src/app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "sinon": "^7.4.2"
   },
   "dependencies": {
-    "@octokit/rest": "16.28.9",
+    "@octokit/rest": "^16.43.2",
     "async": "2.6.3",
     "base-64": "0.1.0",
     "config": "1.31.0",

--- a/src/resources/handle-pull-request.js
+++ b/src/resources/handle-pull-request.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const MAX_ALLOWED_BODY_CHARS = 65536;
+
 const errorTypes = require('../constants/error-types');
 const metadataFormatter = require('../utils/format-pr-metadata');
 
@@ -24,7 +26,7 @@ module.exports = ({ emitter, config }) => (repository, callback) => {
     head: `${config.github.owner}:${config.github.branch}`,
     title: pullRequestMetadata.title,
     base: repository.manifestContent.workingBranch,
-    body: pullRequestMetadata.body
+    body: pullRequestMetadata.body.length > MAX_ALLOWED_BODY_CHARS ? "This repository has too many translation files, Mercury can't return a status description with the PR." : pullRequestMetadata.body.length
   };
 
   let handlePr;

--- a/src/resources/handle-pull-request.js
+++ b/src/resources/handle-pull-request.js
@@ -26,7 +26,7 @@ module.exports = ({ emitter, config }) => (repository, callback) => {
     head: `${config.github.owner}:${config.github.branch}`,
     title: pullRequestMetadata.title,
     base: repository.manifestContent.workingBranch,
-    body: pullRequestMetadata.body.length > MAX_ALLOWED_BODY_CHARS ? "This repository has too many translation files, Mercury can't return a status description with the PR." : pullRequestMetadata.body.length
+    body: pullRequestMetadata.body.length > MAX_ALLOWED_BODY_CHARS ? "This repository has too many translation files, Mercury can't return a status description with the PR." : pullRequestMetadata.body
   };
 
   let handlePr;

--- a/src/services/github.js
+++ b/src/services/github.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const File = require('./github/file');
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 const PullRequest = require('./github/pull-request');
 const RateLimit = require('./github/rate-limit');
 const Reference = require('./github/reference');
@@ -47,7 +47,10 @@ module.exports = config => {
       readOctokit.git
         .getTree(options)
         .then(({ data }) => {
-          next(null, _.map(data.tree, x => x.path));
+          next(
+            null,
+            _.map(data.tree, x => x.path)
+          );
         })
         .catch(err => next(err));
     });

--- a/src/services/github/rate-limit.js
+++ b/src/services/github/rate-limit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const async = require('async');
-const Octokit = require('@octokit/rest');
+const { Octokit } = require('@octokit/rest');
 
 module.exports = config => ({
   get: next => {


### PR DESCRIPTION
This PR does a couple things:
- fixes the issue in the ticket, where PR descriptions above a certain number of characters will make the PR fail. This is the first repo we stumble upon with this issue.
- also enables OSX devs to run Mercury again locally - the `octokit/rest` module that it used was breaking on Monterey.